### PR TITLE
smallvec & cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bencode", "serialize", "deserialize", "serde"]
 [dependencies]
 serde = "1.0.0"
 serde_bytes = "0.10.0"
+smallvec = "0.4.0"
 
 [dev-dependencies]
 serde_derive = "1.0.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -31,6 +31,7 @@ impl<'de, 'a, R: 'a + Read> de::SeqAccess<'de> for BencodeAccess<'a, R> {
 
 impl<'de, 'a, R: 'a + Read> de::MapAccess<'de> for BencodeAccess<'a, R> {
     type Error = Error;
+
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
         where K: de::DeserializeSeed<'de>
     {
@@ -89,6 +90,7 @@ impl<'de, 'a, R: 'a + Read> de::VariantAccess<'de> for BencodeAccess<'a, R> {
 impl<'de, 'a, R: 'a + Read> de::EnumAccess<'de> for BencodeAccess<'a, R> {
     type Error = Error;
     type Variant = Self;
+
     fn variant_seed<V: de::DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self)> {
         match self.de.expect(&[ParseToken::Bytes, ParseToken::Map])? {
             t @ ParseResult::Bytes(_) => {
@@ -242,7 +244,6 @@ impl<'de, R: Read> Deserializer<R> {
 impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     type Error = Error;
 
-    #[inline]
     fn deserialize_any<V: de::Visitor<'de>>(mut self, visitor: V) -> Result<V::Value> {
         match self.parse()? {
             ParseResult::Int(i) => visitor.visit_i64(i),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod value;
 pub use error::{Error, Result};
 pub use ser::{to_bytes, to_string, Serializer};
 pub use de::{from_str, from_bytes, Deserializer};
+pub use value::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate serde;
 extern crate serde_bytes;
+extern crate smallvec;
 
 pub mod error;
 pub mod ser;

--- a/src/ser/string.rs
+++ b/src/ser/string.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::ser;
 use serde::de;
 use error::{Error, Result};
+use smallvec::SmallVec;
 
 struct Expected;
 impl de::Expected for Expected {
@@ -16,80 +17,80 @@ fn unexpected<T>(unexp: de::Unexpected) -> Result<T> {
 }
 
 /// StringSerializer for serializing *just* strings (bytes are also strings in bencode).
-/// The string is returned as Result<Vec<u8>>::Ok without any prefixing (without bencode string
+/// The string is returned as Result<SmallVec<[u8; 16]>>::Ok without any prefixing (without bencode string
 /// length prefix).
 pub struct StringSerializer;
 
 impl<'a> ser::Serializer for &'a mut StringSerializer {
-    type Ok = Vec<u8>;
+    type Ok = SmallVec<[u8; 16]>;
     type Error = Error;
-    type SerializeSeq = ser::Impossible<Vec<u8>, Error>;
-    type SerializeTuple = ser::Impossible<Vec<u8>, Error>;
-    type SerializeTupleStruct = ser::Impossible<Vec<u8>, Error>;
-    type SerializeTupleVariant = ser::Impossible<Vec<u8>, Error>;
-    type SerializeMap = ser::Impossible<Vec<u8>, Error>;
-    type SerializeStruct = ser::Impossible<Vec<u8>, Error>;
-    type SerializeStructVariant = ser::Impossible<Vec<u8>, Error>;
+    type SerializeSeq = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeTuple = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeTupleStruct = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeTupleVariant = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeMap = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeStruct = ser::Impossible<SmallVec<[u8; 16]>, Error>;
+    type SerializeStructVariant = ser::Impossible<SmallVec<[u8; 16]>, Error>;
 
-    fn serialize_bool(self, value: bool) -> Result<Vec<u8>> {
+    fn serialize_bool(self, value: bool) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Bool(value))
     }
-    fn serialize_i8(self, value: i8) -> Result<Vec<u8>> {
+    fn serialize_i8(self, value: i8) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_i64(value as i64)
     }
-    fn serialize_i16(self, value: i16) -> Result<Vec<u8>> {
+    fn serialize_i16(self, value: i16) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_i64(value as i64)
     }
-    fn serialize_i32(self, value: i32) -> Result<Vec<u8>> {
+    fn serialize_i32(self, value: i32) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_i64(value as i64)
     }
-    fn serialize_i64(self, value: i64) -> Result<Vec<u8>> {
+    fn serialize_i64(self, value: i64) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Signed(value))
     }
-    fn serialize_u8(self, value: u8) -> Result<Vec<u8>> {
+    fn serialize_u8(self, value: u8) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_u64(value as u64)
     }
-    fn serialize_u16(self, value: u16) -> Result<Vec<u8>> {
+    fn serialize_u16(self, value: u16) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_u64(value as u64)
     }
-    fn serialize_u32(self, value: u32) -> Result<Vec<u8>> {
+    fn serialize_u32(self, value: u32) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_u64(value as u64)
     }
-    fn serialize_u64(self, value: u64) -> Result<Vec<u8>> {
+    fn serialize_u64(self, value: u64) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Unsigned(value))
     }
-    fn serialize_f32(self, value: f32) -> Result<Vec<u8>> {
+    fn serialize_f32(self, value: f32) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_f64(value as f64)
     }
-    fn serialize_f64(self, value: f64) -> Result<Vec<u8>> {
+    fn serialize_f64(self, value: f64) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Float(value))
     }
-    fn serialize_char(self, value: char) -> Result<Vec<u8>> {
+    fn serialize_char(self, value: char) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_bytes(&[value as u8])
     }
-    fn serialize_str(self, value: &str) -> Result<Vec<u8>> {
+    fn serialize_str(self, value: &str) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_bytes(value.as_bytes())
     }
-    fn serialize_bytes(self, value: &[u8]) -> Result<Vec<u8>> {
+    fn serialize_bytes(self, value: &[u8]) -> Result<SmallVec<[u8; 16]>> {
         Ok(value.into())
     }
-    fn serialize_unit(self) -> Result<Vec<u8>> {
+    fn serialize_unit(self) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Unit)
     }
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Vec<u8>> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<SmallVec<[u8; 16]>> {
         self.serialize_unit()
     }
     fn serialize_unit_variant(self,
                               _name: &'static str,
                               _variant_index: u32,
                               _variant: &'static str)
-                              -> Result<Vec<u8>> {
+                              -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::UnitVariant)
     }
     fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(self,
                                                             _name: &'static str,
                                                             _value: &T)
-                                                            -> Result<Vec<u8>> {
+                                                            -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
     fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(self,
@@ -97,25 +98,25 @@ impl<'a> ser::Serializer for &'a mut StringSerializer {
                                                              _variant_index: u32,
                                                              _variant: &'static str,
                                                              _value: &T)
-                                                             -> Result<Vec<u8>> {
+                                                             -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::NewtypeVariant)
     }
-    fn serialize_none(self) -> Result<Vec<u8>> {
+    fn serialize_none(self) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Option)
     }
-    fn serialize_some<T: ?Sized + ser::Serialize>(self, _value: &T) -> Result<Vec<u8>> {
+    fn serialize_some<T: ?Sized + ser::Serialize>(self, _value: &T) -> Result<SmallVec<[u8; 16]>> {
         unexpected(de::Unexpected::Option)
     }
-    fn serialize_seq(self, _len: Option<usize>) -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_seq(self, _len: Option<usize>) -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::Seq)
     }
-    fn serialize_tuple(self, _size: usize) -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_tuple(self, _size: usize) -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::Seq)
     }
     fn serialize_tuple_struct(self,
                               _name: &'static str,
                               _len: usize)
-                              -> Result<ser::Impossible<Vec<u8>, Error>> {
+                              -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
     fn serialize_tuple_variant(self,
@@ -123,16 +124,16 @@ impl<'a> ser::Serializer for &'a mut StringSerializer {
                                _variant_index: u32,
                                _variant: &'static str,
                                _len: usize)
-                               -> Result<ser::Impossible<Vec<u8>, Error>> {
+                               -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::TupleVariant)
     }
-    fn serialize_map(self, _len: Option<usize>) -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_map(self, _len: Option<usize>) -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::Map)
     }
     fn serialize_struct(self,
                         _name: &'static str,
                         _len: usize)
-                        -> Result<ser::Impossible<Vec<u8>, Error>> {
+                        -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
     fn serialize_struct_variant(self,
@@ -140,7 +141,7 @@ impl<'a> ser::Serializer for &'a mut StringSerializer {
                                 _variant_index: u32,
                                 _variant: &'static str,
                                 _len: usize)
-                                -> Result<ser::Impossible<Vec<u8>, Error>> {
+                                -> Result<ser::Impossible<SmallVec<[u8; 16]>, Error>> {
         unexpected(de::Unexpected::StructVariant)
     }
 }


### PR DESCRIPTION
before this pr:
```
test ser_de_nested ... bench:       1,213 ns/iter (+/- 16)
test ser_de_simple ... bench:         659 ns/iter (+/- 23)
```

after:
```
test ser_de_nested ... bench:       1,007 ns/iter (+/- 7)
test ser_de_simple ... bench:         540 ns/iter (+/- 11)
```