### PR TITLE
Update semver in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-serde_bencode = "^0.1.0"
+serde_bencode = "^0.2.0"
 serde = "^1.0.0"
 serde_derive = "^1.0.0"
 ```


### PR DESCRIPTION
The decoding example won't compile without `serde_bencode = "^0.2.0"`
