### PR TITLE
Made newtype struct deserialization work with derived instances

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -245,7 +245,12 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     forward_to_deserialize_any! {
         i64 string seq bool i8 i16 i32 u8 u16 u32
         u64 f32 f64 char str unit bytes byte_buf map unit_struct tuple_struct tuple
-        newtype_struct ignored_any identifier struct
+        ignored_any identifier struct
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(self, _name: &'static str, visitor: V) -> Result<V::Value> {
+        visitor.visit_newtype_struct(self)
     }
 
     #[inline]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -252,10 +252,11 @@ fn serialize_lexical_sorted_keys() {
 
 #[test]
 fn serialize_newtype_struct() {
-    #[derive(Serialize)]
+    #[derive(Serialize,Deserialize,Debug,Eq,PartialEq)]
     struct Fake(i32);
     let f = Fake(66);
     assert_eq!(to_string(&f).unwrap(), "i66e");
+    test_ser_de_eq(f);
 }
 
 #[test]


### PR DESCRIPTION
At the moment, serde_derive's Deserialize instances on newtype structs expect their visitors to be called with either `visit_seq` or `visit_newtype_struct`, whereas we encode newtype_structs without any form of wrapper, so newtype_structs will always fail to deserialize. 

This change makes `deserialize_newtype_struct` always call `visit_newtype_struct`, which should allow Serde deserialize instances to work.