### PR TITLE
Serialize unicode characters

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -229,8 +229,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         Err(Error::InvalidValue("Cannot serialize f64".to_string()))
     }
     fn serialize_char(self, value: char) -> Result<()> {
-        self.serialize_bytes(&[value as u8])
+        let mut buffer = [0; 4];
+        self.serialize_bytes(value.encode_utf8(&mut buffer).as_bytes())
     }
+
     fn serialize_str(self, value: &str) -> Result<()> {
         self.serialize_bytes(value.as_bytes())
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,6 +93,16 @@ fn serialize_str() {
 }
 
 #[test]
+fn serialize_ascii_char() {
+    assert_eq!(to_string(&'a').unwrap(), "1:a");
+}
+
+#[test]
+fn serialize_uncode_char() {
+    assert_eq!(to_string(&'\u{1F9D0}').unwrap(), "4:\u{01F9D0}");
+}
+
+#[test]
 fn serialize_bool() {
     assert_eq!(to_string(&false).unwrap(), "i0e");
     assert_eq!(to_string(&true).unwrap(), "i1e");


### PR DESCRIPTION
Currently, characters are truncated to 8 bits on serialization. This modifies `serialize_char` to instead serialize characters as their UTF-8 encoding, which allows non-ascii characters to be serialized and deserialized correctly.