### PR TITLE
Updated the project to latest rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ repository = "https://github.com/toby/serde-bencode"
 documentation = "https://docs.rs/serde_bencode/"
 license = "MIT"
 keywords = ["bencode", "serialize", "deserialize", "serde"]
+edition = "2018"
 
 [dependencies]
-serde = "1.0.0"
-serde_bytes = "0.10.0"
+serde = "1.0"
+serde_bytes = "0.11"
 
 [dev-dependencies]
-serde_derive = "1.0.0"
+serde_derive = "1.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::str;
-use serde::de;
-use error::{Error, Result};
+use serde::{de, forward_to_deserialize_any};
+use crate::error::{Error, Result};
 
 pub struct BencodeAccess<'a, R: 'a + Read> {
     de: &'a mut Deserializer<R>,
@@ -219,7 +219,7 @@ impl<'de, R: Read> Deserializer<R> {
         }
         match buf[0] {
             b'i' => Ok(ParseResult::Int(self.parse_int()?)),
-            n @ b'0'...b'9' => Ok(ParseResult::Bytes(self.parse_bytes(n)?)),
+            n @ b'0'..=b'9' => Ok(ParseResult::Bytes(self.parse_bytes(n)?)),
             b'l' => Ok(ParseResult::List),
             b'd' => Ok(ParseResult::Map),
             b'e' => Ok(ParseResult::End),

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,15 +34,15 @@ impl DeError for Error {
         Error::Custom(msg.to_string())
     }
 
-    fn invalid_type(unexp: Unexpected, exp: &Expected) -> Self {
+    fn invalid_type(unexp: Unexpected, exp: &dyn Expected) -> Self {
         Error::InvalidType(format!("Invalid Type: {} (expected: `{}`)", unexp, exp))
     }
 
-    fn invalid_value(unexp: Unexpected, exp: &Expected) -> Self {
+    fn invalid_value(unexp: Unexpected, exp: &dyn Expected) -> Self {
         Error::InvalidValue(format!("Invalid Value: {} (expected: `{}`)", unexp, exp))
     }
 
-    fn invalid_length(len: usize, exp: &Expected) -> Self {
+    fn invalid_length(len: usize, exp: &dyn Expected) -> Self {
         Error::InvalidLength(format!("Invalid Length: {} (expected: {})", len, exp))
     }
 
@@ -68,22 +68,7 @@ impl DeError for Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::IoError(ref error) => StdError::description(error),
-            Error::InvalidType(ref s) => s,
-            Error::InvalidValue(ref s) => s,
-            Error::InvalidLength(ref s) => s,
-            Error::UnknownVariant(ref s) => s,
-            Error::UnknownField(ref s) => s,
-            Error::MissingField(ref s) => s,
-            Error::DuplicateField(ref s) => s,
-            Error::Custom(ref s) => s,
-            Error::EndOfStream => "End of stream",
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::IoError(ref error) => Some(error),
             _ => None,
@@ -93,6 +78,18 @@ impl StdError for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        let message = match *self {
+            Error::IoError(ref error) => {return error.fmt(f)},
+            Error::InvalidType(ref s) => s,
+            Error::InvalidValue(ref s) => s,
+            Error::InvalidLength(ref s) => s,
+            Error::UnknownVariant(ref s) => s,
+            Error::UnknownField(ref s) => s,
+            Error::MissingField(ref s) => s,
+            Error::DuplicateField(ref s) => s,
+            Error::Custom(ref s) => s,
+            Error::EndOfStream => "End of stream",
+        };
+        f.write_str(message)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate serde;
-extern crate serde_bytes;
-
 pub mod error;
 pub mod ser;
 pub mod de;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,7 +3,7 @@ mod string;
 use std::str;
 use std::mem;
 use serde::ser;
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 #[derive(Debug)]
 pub struct Serializer {

--- a/src/ser/string.rs
+++ b/src/ser/string.rs
@@ -2,7 +2,7 @@ use std::str;
 use std::fmt;
 use serde::ser;
 use serde::de;
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 struct Expected;
 impl de::Expected for Expected {

--- a/src/value.rs
+++ b/src/value.rs
@@ -27,10 +27,10 @@ impl ser::Serialize for Value {
                 }
                 seq.end()
             }
-            Value::Dict(ref v) => {
-                let mut map = s.serialize_map(Some(v.len()))?;
-                for (k, v) in v {
-                    map.serialize_entry(&Bytes::from(k.as_ref()), v)?;
+            Value::Dict(ref vs) => {
+                let mut map = s.serialize_map(Some(vs.len()))?;
+                for (k, v) in vs {
+                    map.serialize_entry(&Bytes::new(k), v)?;
                 }
                 map.end()
             }
@@ -92,7 +92,7 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
     {
         let mut map = HashMap::new();
         while let Some((k, v)) = access.next_entry::<ByteBuf, _>()? {
-            map.insert(k.into(), v);
+            map.insert(k.into_vec(), v);
         }
         Ok(Value::Dict(map))
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,3 @@
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_bencode;
 
 use serde_bencode::value::Value;
@@ -8,7 +5,8 @@ use serde_bencode::de::{from_bytes, from_str};
 use serde_bencode::ser::{Serializer, to_bytes, to_string};
 use serde_bencode::error::Result;
 use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
+use serde::{Serialize, Deserialize};
+use serde_derive::{Serialize, Deserialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 


### PR DESCRIPTION
The edition was updated to 2018 and all the warnings were fixed, mainly
errors using the old description API instead of fmt::Display.
Removed extern crate not needed in Rust 2018.
Updated all the dependencies to the latest version and fixing the broken
changes specially serde_bytes that changed its API.

(This is my first PR so if there is anything wrong please tell me)