### PR TITLE
Fix deserialization of nested tuple

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -423,3 +423,9 @@ fn ser_de_flattened_adjacently_tagged_enum() {
         body: Body::Request { token: 456 },
     });
 }
+
+// https://github.com/toby/serde-bencode/issues/16 (simplified)
+#[test]
+fn ser_de_vec_of_tuples() {
+    test_ser_de_eq(vec![(1, 2), (3, 4)]);
+}


### PR DESCRIPTION
When deserializing tuples, pass the expected tuple length into `visit_seq` to make sure the end-of-list marker ("e") is removed from the input.

Fixes #16 