### PR TITLE
Introduce failing test for flattened enums

### DIFF
--- a/examples/parse_torrent.rs
+++ b/examples/parse_torrent.rs
@@ -1,12 +1,12 @@
-extern crate serde_bencode;
 extern crate serde;
+extern crate serde_bencode;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_bytes;
 
 use serde_bencode::de;
-use std::io::{self, Read};
 use serde_bytes::ByteBuf;
+use std::io::{self, Read};
 
 #[derive(Debug, Deserialize)]
 struct Node(String, i64);
@@ -23,7 +23,7 @@ struct File {
 struct Info {
     name: String,
     pieces: ByteBuf,
-    #[serde(rename="piece length")]
+    #[serde(rename = "piece length")]
     piece_length: i64,
     #[serde(default)]
     md5sum: Option<String>,
@@ -36,7 +36,7 @@ struct Info {
     #[serde(default)]
     path: Option<Vec<String>>,
     #[serde(default)]
-    #[serde(rename="root hash")]
+    #[serde(rename = "root hash")]
     root_hash: Option<String>,
 }
 
@@ -52,15 +52,15 @@ struct Torrent {
     #[serde(default)]
     httpseeds: Option<Vec<String>>,
     #[serde(default)]
-    #[serde(rename="announce-list")]
+    #[serde(rename = "announce-list")]
     announce_list: Option<Vec<Vec<String>>>,
     #[serde(default)]
-    #[serde(rename="creation date")]
+    #[serde(rename = "creation date")]
     creation_date: Option<i64>,
-    #[serde(rename="comment")]
+    #[serde(rename = "comment")]
     comment: Option<String>,
     #[serde(default)]
-    #[serde(rename="created by")]
+    #[serde(rename = "created by")]
     created_by: Option<String>,
 }
 
@@ -68,7 +68,7 @@ fn render_torrent(torrent: &Torrent) {
     println!("name:\t\t{}", torrent.info.name);
     println!("announce:\t{:?}", torrent.announce);
     println!("nodes:\t\t{:?}", torrent.nodes);
-    if let &Some(ref al) = &torrent.announce_list {
+    if let Some(al) = &torrent.announce_list {
         for a in al {
             println!("announce list:\t{}", a[0]);
         }
@@ -83,7 +83,7 @@ fn render_torrent(torrent: &Torrent) {
     println!("root hash:\t{:?}", torrent.info.root_hash);
     println!("md5sum:\t\t{:?}", torrent.info.md5sum);
     println!("path:\t\t{:?}", torrent.info.path);
-    if let &Some(ref files) = &torrent.info.files {
+    if let Some(files) = &torrent.info.files {
         for f in files {
             println!("file path:\t{:?}", f.path);
             println!("file length:\t{}", f.length);
@@ -97,13 +97,10 @@ fn main() {
     let mut buffer = Vec::new();
     let mut handle = stdin.lock();
     match handle.read_to_end(&mut buffer) {
-        Ok(_) => {
-            match de::from_bytes::<Torrent>(&buffer) {
-                Ok(t) => render_torrent(&t),
-                Err(e) => println!("ERROR: {:?}", e),
-            }
-        }
+        Ok(_) => match de::from_bytes::<Torrent>(&buffer) {
+            Ok(t) => render_torrent(&t),
+            Err(e) => println!("ERROR: {:?}", e),
+        },
         Err(e) => println!("ERROR: {:?}", e),
-
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 //! Structures used to handle errors when serializing or deserializing goes wrong.
 
+use serde::de::Error as DeError;
+use serde::de::{Expected, Unexpected};
+use serde::ser::Error as SerError;
+use std::error::Error as StdError;
 use std::fmt;
 use std::fmt::Display;
-use std::error::Error as StdError;
 use std::io::Error as IoError;
 use std::result::Result as StdResult;
-use serde::ser::Error as SerError;
-use serde::de::Error as DeError;
-use serde::de::{Unexpected, Expected};
 
 /// Alias for `Result<T, serde_bencode::Error>`.
 pub type Result<T> = StdResult<T, Error>;
@@ -25,7 +25,7 @@ pub enum Error {
     /// reason. For example, this error may occur when deserializing to a String but the input data
     /// is not valid UTF-8.
     InvalidValue(String),
-    
+
     /// Raised when deserializing a sequence or map, but the input data is the wrong length.
     InvalidLength(String),
 
@@ -74,15 +74,17 @@ impl DeError for Error {
     }
 
     fn unknown_variant(field: &str, expected: &'static [&'static str]) -> Self {
-        Error::UnknownVariant(format!("Unknown Variant: `{}` (expected one of: {:?})",
-                                      field,
-                                      expected))
+        Error::UnknownVariant(format!(
+            "Unknown Variant: `{}` (expected one of: {:?})",
+            field, expected
+        ))
     }
 
     fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
-        Error::UnknownField(format!("Unknown Field: `{}` (expected one of: {:?})",
-                                    field,
-                                    expected))
+        Error::UnknownField(format!(
+            "Unknown Field: `{}` (expected one of: {:?})",
+            field, expected
+        ))
     }
 
     fn missing_field(field: &'static str) -> Self {
@@ -106,7 +108,7 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let message = match *self {
-            Error::IoError(ref error) => {return error.fmt(f)},
+            Error::IoError(ref error) => return error.fmt(f),
             Error::InvalidType(ref s) => s,
             Error::InvalidValue(ref s) => s,
             Error::InvalidLength(ref s) => s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@
 //! }
 //! ```
 
+pub mod de;
 pub mod error;
 pub mod ser;
-pub mod de;
 pub mod value;
 
+pub use de::{from_bytes, from_str, Deserializer};
 pub use error::{Error, Result};
 pub use ser::{to_bytes, to_string, Serializer};
-pub use de::{from_str, from_bytes, Deserializer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -365,8 +365,8 @@ impl<'a> ser::Serializer for &'a mut Serializer {
 ///
 /// let bytes = serde_bencode::to_bytes(&address)?;
 /// assert_eq!(
-///     String::from_utf8(bytes),
-///     Ok("d4:city18:Duckburg, Calisota6:street17:1313 Webfoot Walke".to_string()),
+///     String::from_utf8(bytes).unwrap(),
+///     "d4:city18:Duckburg, Calisota6:street17:1313 Webfoot Walke",
 /// );
 /// # Ok(())
 /// # }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,10 +2,10 @@
 
 mod string;
 
-use std::str;
-use std::mem;
-use serde::ser;
 use crate::error::{Error, Result};
+use serde::ser;
+use std::mem;
+use std::str;
 
 /// A structure for serializing Rust values into bencode.
 #[derive(Debug)]
@@ -100,7 +100,9 @@ impl<'a> SerializeMap<'a> {
 
     fn end_map(&mut self) -> Result<()> {
         if self.cur_key.is_some() {
-            return Err(Error::InvalidValue("`serialize_key` called without calling  `serialize_value`".to_string()));
+            return Err(Error::InvalidValue(
+                "`serialize_key` called without calling  `serialize_value`".to_string(),
+            ));
         }
         let mut entries = mem::replace(&mut self.entries, Vec::new());
         entries.sort_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
@@ -119,16 +121,18 @@ impl<'a> ser::SerializeMap for SerializeMap<'a> {
     type Error = Error;
     fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, key: &T) -> Result<()> {
         if self.cur_key.is_some() {
-            return Err(Error::InvalidValue("`serialize_key` called multiple times without calling  `serialize_value`".to_string()));
+            return Err(Error::InvalidValue(
+                "`serialize_key` called multiple times without calling  `serialize_value`"
+                    .to_string(),
+            ));
         }
         self.cur_key = Some(key.serialize(&mut string::StringSerializer)?);
         Ok(())
     }
     fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        let key = self.cur_key
-            .take()
-            .ok_or(Error::InvalidValue("`serialize_value` called without calling `serialize_key`"
-                                           .to_string()))?;
+        let key = self.cur_key.take().ok_or(Error::InvalidValue(
+            "`serialize_value` called without calling `serialize_key`".to_string(),
+        ))?;
         let mut ser = Serializer::new();
         value.serialize(&mut ser)?;
         let value = ser.into_vec();
@@ -138,11 +142,15 @@ impl<'a> ser::SerializeMap for SerializeMap<'a> {
         Ok(())
     }
     fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<()>
-        where K: ?Sized + ser::Serialize,
-              V: ?Sized + ser::Serialize
+    where
+        K: ?Sized + ser::Serialize,
+        V: ?Sized + ser::Serialize,
     {
         if self.cur_key.is_some() {
-            return Err(Error::InvalidValue("`serialize_key` called multiple times without calling  `serialize_value`".to_string()));
+            return Err(Error::InvalidValue(
+                "`serialize_key` called multiple times without calling  `serialize_value`"
+                    .to_string(),
+            ));
         }
         let key = key.serialize(&mut string::StringSerializer)?;
         let mut ser = Serializer::new();
@@ -161,10 +169,11 @@ impl<'a> ser::SerializeMap for SerializeMap<'a> {
 impl<'a> ser::SerializeStruct for SerializeMap<'a> {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self,
-                                                   key: &'static str,
-                                                   value: &T)
-                                                   -> Result<()> {
+    fn serialize_field<T: ?Sized + ser::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<()> {
         ser::SerializeMap::serialize_entry(self, key, value)
     }
     fn end(mut self) -> Result<()> {
@@ -175,10 +184,11 @@ impl<'a> ser::SerializeStruct for SerializeMap<'a> {
 impl<'a> ser::SerializeStructVariant for SerializeMap<'a> {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self,
-                                                   key: &'static str,
-                                                   value: &T)
-                                                   -> Result<()> {
+    fn serialize_field<T: ?Sized + ser::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<()> {
         ser::SerializeMap::serialize_entry(self, key, value)
     }
     fn end(mut self) -> Result<()> {
@@ -258,25 +268,28 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
         self.serialize_unit()
     }
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              variant: &'static str)
-                              -> Result<()> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<()> {
         self.serialize_str(variant)
     }
-    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(self,
-                                                            _name: &'static str,
-                                                            value: &T)
-                                                            -> Result<()> {
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<()> {
         value.serialize(self)
     }
-    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(self,
-                                                             _name: &'static str,
-                                                             _variant_index: u32,
-                                                             variant: &'static str,
-                                                             value: &T)
-                                                             -> Result<()> {
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<()> {
         self.push("d");
         self.serialize_bytes(variant.as_bytes())?;
         value.serialize(&mut *self)?;
@@ -299,12 +312,13 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     fn serialize_tuple_struct(self, _name: &'static str, len: usize) -> Result<Self> {
         self.serialize_seq(Some(len))
     }
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               variant: &'static str,
-                               _len: usize)
-                               -> Result<Self::SerializeTupleVariant> {
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
         self.push("d");
         self.serialize_bytes(variant.as_bytes())?;
         self.push("l");
@@ -316,12 +330,13 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
         self.serialize_map(Some(len))
     }
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                variant: &'static str,
-                                len: usize)
-                                -> Result<Self::SerializeStructVariant> {
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
         self.push("d");
         self.serialize_bytes(variant.as_bytes())?;
         Ok(SerializeMap::new(self, len))
@@ -329,7 +344,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
 }
 
 /// Serialize the given data into a bencode byte vector.
-/// 
+///
 /// # Examples
 /// ```
 /// # fn main() -> Result<(), serde_bencode::Error> {

--- a/src/ser/string.rs
+++ b/src/ser/string.rs
@@ -1,10 +1,10 @@
 //! Serializer for serializing *just* strings.
 
-use std::str;
-use std::fmt;
-use serde::ser;
-use serde::de;
 use crate::error::{Error, Result};
+use serde::de;
+use serde::ser;
+use std::fmt;
+use std::str;
 
 struct Expected;
 impl de::Expected for Expected {
@@ -83,25 +83,28 @@ impl<'a> ser::Serializer for &'a mut StringSerializer {
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Vec<u8>> {
         self.serialize_unit()
     }
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              _variant: &'static str)
-                              -> Result<Vec<u8>> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Vec<u8>> {
         unexpected(de::Unexpected::UnitVariant)
     }
-    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(self,
-                                                            _name: &'static str,
-                                                            _value: &T)
-                                                            -> Result<Vec<u8>> {
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Vec<u8>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
-    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(self,
-                                                             _name: &'static str,
-                                                             _variant_index: u32,
-                                                             _variant: &'static str,
-                                                             _value: &T)
-                                                             -> Result<Vec<u8>> {
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Vec<u8>> {
         unexpected(de::Unexpected::NewtypeVariant)
     }
     fn serialize_none(self) -> Result<Vec<u8>> {
@@ -116,35 +119,39 @@ impl<'a> ser::Serializer for &'a mut StringSerializer {
     fn serialize_tuple(self, _size: usize) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::Seq)
     }
-    fn serialize_tuple_struct(self,
-                              _name: &'static str,
-                              _len: usize)
-                              -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               _variant: &'static str,
-                               _len: usize)
-                               -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::TupleVariant)
     }
     fn serialize_map(self, _len: Option<usize>) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::Map)
     }
-    fn serialize_struct(self,
-                        _name: &'static str,
-                        _len: usize)
-                        -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::NewtypeStruct)
     }
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                _variant: &'static str,
-                                _len: usize)
-                                -> Result<ser::Impossible<Vec<u8>, Error>> {
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<Vec<u8>, Error>> {
         unexpected(de::Unexpected::StructVariant)
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,10 @@
 //! Structures for representing bencoded values with Rust data types.
 
+use serde::de;
+use serde::ser::{self, SerializeMap, SerializeSeq};
+use serde_bytes::{ByteBuf, Bytes};
 use std::collections::HashMap;
 use std::fmt;
-use serde::de;
-use serde::ser::{self, SerializeSeq, SerializeMap};
-use serde_bytes::{Bytes, ByteBuf};
 
 /// All possible values which may be serialized in bencode.
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -25,7 +25,8 @@ pub enum Value {
 impl ser::Serialize for Value {
     #[inline]
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-        where S: ser::Serializer
+    where
+        S: ser::Serializer,
     {
         match *self {
             Value::Bytes(ref v) => s.serialize_bytes(v),
@@ -48,7 +49,6 @@ impl ser::Serialize for Value {
     }
 }
 
-
 struct ValueVisitor;
 
 impl<'de> de::Visitor<'de> for ValueVisitor {
@@ -70,7 +70,8 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
 
     #[inline]
     fn visit_str<E>(self, value: &str) -> Result<Value, E>
-        where E: de::Error
+    where
+        E: de::Error,
     {
         Ok(Value::Bytes(value.into()))
     }
@@ -87,7 +88,8 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
 
     #[inline]
     fn visit_seq<V>(self, mut access: V) -> Result<Value, V::Error>
-        where V: de::SeqAccess<'de>
+    where
+        V: de::SeqAccess<'de>,
     {
         let mut seq = Vec::new();
         while let Some(e) = access.next_element()? {
@@ -98,7 +100,8 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
 
     #[inline]
     fn visit_map<V>(self, mut access: V) -> Result<Value, V::Error>
-        where V: de::MapAccess<'de>
+    where
+        V: de::MapAccess<'de>,
     {
         let mut map = HashMap::new();
         while let Some((k, v)) = access.next_entry::<ByteBuf, _>()? {
@@ -111,7 +114,8 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
 impl<'de> de::Deserialize<'de> for Value {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
-        where D: de::Deserializer<'de>
+    where
+        D: de::Deserializer<'de>,
     {
         deserializer.deserialize_any(ValueVisitor)
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -401,3 +401,25 @@ fn ser_de_adjacently_tagged_enum() {
     test_ser_de_eq(Mock::A);
     test_ser_de_eq(Mock::B);
 }
+
+#[test]
+fn ser_de_flattened_adjacently_tagged_enum() {
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct Message {
+        id: u64,
+        #[serde(flatten)]
+        body: Body,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    #[serde(tag = "type", content = "content")]
+    enum Body {
+        Request { token: u64 },
+        Response,
+    }
+
+    test_ser_de_eq(Message {
+        id: 123,
+        body: Body::Request { token: 456 },
+    });
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -423,3 +423,9 @@ fn ser_de_flattened_adjacently_tagged_enum() {
         body: Body::Request { token: 456 },
     });
 }
+
+// https://github.com/toby/serde-bencode/issues/16 (simplified)
+#[test]
+fn ser_de_vec_of_tuples() {
+    test_ser_de_eq(vec![(1, 2), (3, 4)]);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -388,3 +388,16 @@ fn ser_de_variant_struct() {
 fn test_to_bytes() {
     assert_eq!(to_bytes(&"test").unwrap(), b"4:test");
 }
+
+#[test]
+fn ser_de_adjacently_tagged_enum() {
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    #[serde(tag = "t", content = "c")]
+    enum Mock {
+        A,
+        B,
+    }
+
+    test_ser_de_eq(Mock::A);
+    test_ser_de_eq(Mock::B);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -429,3 +429,18 @@ fn ser_de_flattened_adjacently_tagged_enum() {
 fn ser_de_vec_of_tuples() {
     test_ser_de_eq(vec![(1, 2), (3, 4)]);
 }
+
+// https://github.com/toby/serde-bencode/issues/17
+#[test]
+fn ser_de_field_vec_tuple() {
+    #[derive(Deserialize, Serialize, Eq, PartialEq, Debug)]
+    struct Foo {
+        bar: Vec<(u16,)>,
+    }
+
+    let foo = Foo {
+        bar: vec![(1,), (3,)],
+    };
+
+    test_ser_de_eq(foo);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -444,3 +444,35 @@ fn ser_de_field_vec_tuple() {
 
     test_ser_de_eq(foo);
 }
+
+#[test]
+fn ser_de_flattened_enum() {
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct KrpcMessage {
+        message_type: MessageType,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    enum MessageType {
+        Query,
+        Response,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct KrpcResponse {
+        #[serde(flatten)]
+        krpc: KrpcMessage,
+    }
+
+    // Passes
+    test_ser_de_eq(KrpcMessage {
+        message_type: MessageType::Response,
+    });
+
+    // Fails
+    test_ser_de_eq(KrpcResponse {
+        krpc: KrpcMessage {
+            message_type: MessageType::Response,
+        },
+    });
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 extern crate serde_bencode;
 
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_bencode::de::{from_bytes, from_str};
 use serde_bencode::error::Result;
 use serde_bencode::ser::{to_bytes, to_string, Serializer};
@@ -178,7 +178,7 @@ fn serialize_struct() {
     struct Fake {
         x: i64,
         y: String,
-    };
+    }
     let f = Fake {
         x: 1111,
         y: "dog".to_string(),
@@ -193,7 +193,7 @@ fn deserialize_to_struct() {
     struct Fake {
         y: String,
         x: i64,
-    };
+    }
     assert_eq!(
         from_str::<Fake>(b).unwrap(),
         Fake {
@@ -214,7 +214,7 @@ fn deserialize_to_struct_with_option() {
         z: Option<String>,
         #[serde(default)]
         a: Option<String>,
-    };
+    }
     let r: Fake = from_str(b).unwrap();
     assert_eq!(
         r,
@@ -246,7 +246,7 @@ fn deserialize_to_value_struct_mix() {
         x: i64,
         z: Value,
         q: Vec<i64>,
-    };
+    }
     let r: Fake = from_str(b).unwrap();
     assert_eq!(
         r,
@@ -267,7 +267,7 @@ fn serialize_lexical_sorted_keys() {
         bb: i32,
         z: i32,
         c: i32,
-    };
+    }
     let f = Fake {
         aaa: 1,
         bb: 2,
@@ -324,7 +324,7 @@ fn struct_none_vals() {
     struct Fake {
         a: Option<i32>,
         b: Option<i32>,
-    };
+    }
     let f = Fake {
         a: None,
         b: Some(1),
@@ -338,7 +338,7 @@ fn ser_de_variant_unit() {
     enum Mock {
         A,
         B,
-    };
+    }
     test_ser_de_eq(("pre".to_string(), Mock::A, "post".to_string()));
     test_ser_de_eq(("pre".to_string(), Mock::B, "post".to_string()));
 }
@@ -349,7 +349,7 @@ fn ser_de_variant_newtype() {
     enum Mock {
         A(i64),
         B(i64),
-    };
+    }
     test_ser_de_eq(("pre".to_string(), Mock::A(123), "post".to_string()));
     test_ser_de_eq(("pre".to_string(), Mock::B(321), "post".to_string()));
 }
@@ -360,7 +360,7 @@ fn ser_de_variant_tuple() {
     enum Mock {
         A(i64, i64),
         B(i64, i64),
-    };
+    }
     test_ser_de_eq(("pre".to_string(), Mock::A(123, 321), "post".to_string()));
     test_ser_de_eq(("pre".to_string(), Mock::B(321, 123), "post".to_string()));
 }
@@ -371,7 +371,7 @@ fn ser_de_variant_struct() {
     enum Mock {
         A { a: i64, b: i64 },
         B { c: i64, d: i64 },
-    };
+    }
     test_ser_de_eq((
         "pre".to_string(),
         Mock::A { a: 123, b: 321 },

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,12 @@
 extern crate serde_bencode;
 
-use serde_bencode::value::Value;
-use serde_bencode::de::{from_bytes, from_str};
-use serde_bencode::ser::{Serializer, to_bytes, to_string};
-use serde_bencode::error::Result;
 use serde::de::DeserializeOwned;
-use serde::{Serialize, Deserialize};
-use serde_derive::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use serde_bencode::de::{from_bytes, from_str};
+use serde_bencode::error::Result;
+use serde_bencode::ser::{to_bytes, to_string, Serializer};
+use serde_bencode::value::Value;
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 
@@ -26,7 +26,8 @@ fn test_value_de_ser(s: &str) {
 }
 
 fn test_ser_de_eq<T>(a: T)
-    where T: Serialize + DeserializeOwned + Debug + Eq
+where
+    T: Serialize + DeserializeOwned + Debug + Eq,
 {
     let mut ser = Serializer::new();
     a.serialize(&mut ser).unwrap();
@@ -47,18 +48,25 @@ fn ser_de_string() {
 
 #[test]
 fn ser_de_value_list_mixed() {
-    test_value_ser_de(Value::List(vec!["one".into(), "two".into(), "three".into(), 4i64.into()]));
+    test_value_ser_de(Value::List(vec![
+        "one".into(),
+        "two".into(),
+        "three".into(),
+        4i64.into(),
+    ]));
 }
 
 #[test]
 fn ser_de_value_list_nested() {
     let l_grandchild = Value::List(vec!["two".into()]);
     let l_child = Value::List(vec!["one".into(), l_grandchild]);
-    test_value_ser_de(vec!["one".into(),
-                           "two".into(),
-                           "three".into(),
-                           4i64.into(),
-                           l_child]);
+    test_value_ser_de(vec![
+        "one".into(),
+        "two".into(),
+        "three".into(),
+        4i64.into(),
+        l_child,
+    ]);
 }
 
 #[test]
@@ -72,7 +80,12 @@ fn ser_de_value_map() {
 fn ser_de_map_value_mixed() {
     let mut ma = HashMap::new();
     ma.insert("M jr.".into(), "nuggets".into());
-    let s = Value::List(vec!["one".into(), "two".into(), "three".into(), 4i64.into()]);
+    let s = Value::List(vec![
+        "one".into(),
+        "two".into(),
+        "three".into(),
+        4i64.into(),
+    ]);
     let mut m = HashMap::new();
     m.insert("Mc".into(), "Burger".into());
     m.insert("joint".into(), ma.into());
@@ -181,11 +194,13 @@ fn deserialize_to_struct() {
         y: String,
         x: i64,
     };
-    assert_eq!(from_str::<Fake>(b).unwrap(),
-               Fake {
-                   x: 1111,
-                   y: "dog".to_string(),
-               });
+    assert_eq!(
+        from_str::<Fake>(b).unwrap(),
+        Fake {
+            x: 1111,
+            y: "dog".to_string(),
+        }
+    );
 }
 
 #[test]
@@ -201,13 +216,15 @@ fn deserialize_to_struct_with_option() {
         a: Option<String>,
     };
     let r: Fake = from_str(b).unwrap();
-    assert_eq!(r,
-               Fake {
-                   x: 1111,
-                   y: "dog".to_string(),
-                   z: Some("yo".to_string()),
-                   a: None,
-               });
+    assert_eq!(
+        r,
+        Fake {
+            x: 1111,
+            y: "dog".to_string(),
+            z: Some("yo".to_string()),
+            a: None,
+        }
+    );
 }
 
 #[test]
@@ -231,13 +248,15 @@ fn deserialize_to_value_struct_mix() {
         q: Vec<i64>,
     };
     let r: Fake = from_str(b).unwrap();
-    assert_eq!(r,
-               Fake {
-                   x: 1111,
-                   y: "dog".to_string(),
-                   z: Value::Int(66),
-                   q: vec![666],
-               });
+    assert_eq!(
+        r,
+        Fake {
+            x: 1111,
+            y: "dog".to_string(),
+            z: Value::Int(66),
+            q: vec![666],
+        }
+    );
 }
 
 #[test]
@@ -260,7 +279,7 @@ fn serialize_lexical_sorted_keys() {
 
 #[test]
 fn serialize_newtype_struct() {
-    #[derive(Serialize,Deserialize,Debug,Eq,PartialEq)]
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
     struct Fake(i32);
     let f = Fake(66);
     assert_eq!(to_string(&f).unwrap(), "i66e");
@@ -353,8 +372,16 @@ fn ser_de_variant_struct() {
         A { a: i64, b: i64 },
         B { c: i64, d: i64 },
     };
-    test_ser_de_eq(("pre".to_string(), Mock::A { a: 123, b: 321 }, "post".to_string()));
-    test_ser_de_eq(("pre".to_string(), Mock::B { c: 321, d: 123 }, "post".to_string()));
+    test_ser_de_eq((
+        "pre".to_string(),
+        Mock::A { a: 123, b: 321 },
+        "post".to_string(),
+    ));
+    test_ser_de_eq((
+        "pre".to_string(),
+        Mock::B { c: 321, d: 123 },
+        "post".to_string(),
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Hello,

This pull request adds a failing test for deserializing flattened structs containing enums.

Is it expected that this test should pass or is there some `serde` caveat that I'm unaware of here? I'm happy to take a crack at fixing this if it's fixable. Any pointers would be appreciated.

Thanks.

