### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Checking](https://github.com/torrust/torrust-serde-bencode/actions/workflows/checking.yml/badge.svg)](https://github.com/torrust/torrust-serde-bencode/actions/workflows/checking.yml) [![Formatting](https://github.com/torrust/torrust-serde-bencode/actions/workflows/formatting.yml/badge.svg)](https://github.com/torrust/torrust-serde-bencode/actions/workflows/formatting.yml) [![Testing](https://github.com/torrust/torrust-serde-bencode/actions/workflows/testing.yaml/badge.svg)](https://github.com/torrust/torrust-serde-bencode/actions/workflows/testing.yaml) [![Benchmarking](https://github.com/torrust/torrust-serde-bencode/actions/workflows/benchmarking.yml/badge.svg)](https://github.com/torrust/torrust-serde-bencode/actions/workflows/benchmarking.yml) [![Coverage](https://github.com/torrust/torrust-serde-bencode/actions/workflows/coverage.yaml/badge.svg)](https://github.com/torrust/torrust-serde-bencode/actions/workflows/coverage.yaml) [![Crates.io](https://img.shields.io/crates/v/serde_bencode)](https://crates.io/crates/serde_bencode) [![docs.rs](https://img.shields.io/docsrs/serde_bencode)](https://docs.rs/serde_bencode)
 
-**Archived:** I no longer maintain this repo as I've moved to [Go full-time](https://charm.sh). Please see [torrust/torrust-serde-bencode](https://github.com/torrust/torrust-serde-bencode) for a maintained fork.
-
 A [Serde](https://github.com/serde-rs/serde) backed [Bencode](https://en.wikipedia.org/wiki/Bencode)
 encoding/decoding library for Rust.
 


### PR DESCRIPTION
Remove message:

>Archived: I no longer maintain this repo as I've moved to [Go full-time](https://charm.sh/). Please see [torrust/torrust-serde-bencode](https://github.com/torrust/torrust-serde-bencode) for a maintained fork.

In the end, I was added as a maintainer and [merged upgrades from the fork](https://github.com/toby/serde-bencode/pull/34).