### PR TITLE
feat: set is_human_readable to false

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -213,6 +213,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     type SerializeStruct = SerializeMap<'a>;
     type SerializeStructVariant = SerializeMap<'a>;
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     fn serialize_bool(self, value: bool) -> Result<()> {
         self.serialize_i64(i64::from(value))
     }


### PR DESCRIPTION
This allows implementations of Serialize to change behavior depending on the encoding method used (e.g. encode as base64 for human readable encodings such as JSON, and encode as binary strings for bencode).